### PR TITLE
stackStringA and stackStringW for more recent nim compilers

### DIFF
--- a/src/Bitmancer/core/str.nim
+++ b/src/Bitmancer/core/str.nim
@@ -72,27 +72,25 @@ const
 
 ## Stack Strings
 ##------------------------------------
-macro stackStringA*(varName: untyped, varType: untyped, varValue: static string) =
-    result = newStmtList()
-    let 
-        bracketExpr = makeBracketExpression(varValue, false)
-        identDef    = newIdentDefs(varName, bracketExpr)
-        varSect     = newNimNode(nnkVarSection).add identDef
-    result.add varSect
-    result.assignChars(varName, varValue, false)
-    when defined(nimDumpStackStrings):
-        echo repr result
+macro stackStringA*(sect) =
+  result = newStmtList()
+  let
+    def = sect[0]
+    bracketExpr = makeBracketExpression(def[2].strVal, false)
+    identDef = newIdentDefs(def[0], bracketExpr)
+    varSect = newNimNode(nnkVarSection).add(identDef)
+  result.add(varSect)
+  result.assignChars(def[0], def[2].strVal, false)
 
-macro stackStringW*(varName: untyped, varType: untyped, varValue: static string) =
-    result = newStmtList()
-    let 
-        bracketExpr = makeBracketExpression(varValue, true)
-        identDef    = newIdentDefs(varName, bracketExpr)
-        varSect     = newNimNode(nnkVarSection).add identDef
-    result.add varSect
-    result.assignChars(varName, varValue, true)
-    when defined(nimDumpStackStrings):
-        echo repr result
+macro stackStringW*(sect) =
+  result = newStmtList()
+  let
+    def = sect[0]
+    bracketExpr = makeBracketExpression(def[2].strVal, true)
+    identDef = newIdentDefs(def[0], bracketExpr)
+    varSect = newNimNode(nnkVarSection).add(identDef)
+  result.add(varSect)
+  result.assignChars(def[0], def[2].strVal, true)
 
 ## Utility Templates
 ##------------------------------------


### PR DESCRIPTION
Updates stackStringA and stackStringW macros to work on more recent nim compilers (2.0 +)
This is not backwards compatible with nim 1.6.8 - 1.6.14, as it seems macros may have changed with the release of 2.0.0